### PR TITLE
SMC-278: Add more flexibility

### DIFF
--- a/Test/ERC20.test.js
+++ b/Test/ERC20.test.js
@@ -27,7 +27,7 @@ const totalAddressCreated = testHelper.generateRandomizedNumber(10, 20)
 
 // describe('Test for ERC20 Functions', ERC20Test("TestERC20",TOKEN_NAME, TOKEN_SYMBOL, STANDARD_MINT_AMOUNT, FAUCET_MINT));
 
-async function ERC20Test(contractName, tokenName, tokenSymbol, mintAmount, faucetMint) {
+async function ERC20Test(contractName, tokenName, tokenSymbol, tokenDecimals, mintAmount, faucetMint, initialize, errorMsgs) {
     before(async function () {
         [owner, faucet1, faucet2] = await ethers.getSigners();
         users = await testHelper.createWallets(totalAddressCreated, faucet1);
@@ -36,6 +36,7 @@ async function ERC20Test(contractName, tokenName, tokenSymbol, mintAmount, fauce
 
     beforeEach(async function () {
         TestToken = await this.contractFactory.deploy();
+        if (initialize) await initialize(TestToken, owner);
         for (var i = 0; i < totalAddressCreated; i++) {
             await TestToken[faucetMint](users[i].address, mintAmount);
         }
@@ -52,7 +53,7 @@ async function ERC20Test(contractName, tokenName, tokenSymbol, mintAmount, fauce
         });
 
         it('Token decimals is correct', async function () {
-            expect(await TestToken.decimals()).to.equal(DECIMALS);
+            expect(await TestToken.decimals()).to.equal(tokenDecimals);
         });
 
         it('Total supply test', async function () {

--- a/Test/Reserve.test.js
+++ b/Test/Reserve.test.js
@@ -28,7 +28,7 @@ const totalAddressCreated = testHelper.generateRandomizedNumber(10, 20);
 
 // describe('Test for Reserveable Functions', ReserveableTest("Test", STANDARD_MINT_AMOUNT, FAUCET_MINT));
 
-async function ReserveableTest(contractName, mintAmount, faucetMint) {
+async function ReserveableTest(contractName, mintAmount, faucetMint, initialize, errorMsgs, reservableFunctions) {
     before(async function () {
         [owner, faucet1, faucet2] = await ethers.getSigners();
         users = await testHelper.createWallets(totalAddressCreated, faucet1);
@@ -37,6 +37,7 @@ async function ReserveableTest(contractName, mintAmount, faucetMint) {
 
     beforeEach(async function () {
         TestToken = await this.contractFactory.deploy();
+        if (initialize) await initialize(TestToken, owner);
         for (var i = 0; i < totalAddressCreated; i++) {
             await TestToken[faucetMint](users[i].address, mintAmount);
         }


### PR DESCRIPTION
# Notable change
- Add more flexibility to this utilities to be able to use it in SMC-278 (Invest Token repo)
- Inject a initialize function (call only if pass to the function) allowing to add more transactions between the contract deployment and initial mint (initialize, grant role, setup...)
- Inject errorMsgs to allow to overwrite some errors msg
- Allow overwriting reservableFunctions